### PR TITLE
test : delete deprecated module

### DIFF
--- a/src/hooks/useChat.spec.ts
+++ b/src/hooks/useChat.spec.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
 import { useChat } from "./useChat";
 import { Client } from "@stomp/stompjs";
 


### PR DESCRIPTION
---
name: delete deprecated module
about: "delete deprecated module."
title: "[Fix] - useChat.sepc.ts 파일의 deprecated된 import 수정"
labels: ""
assignees: "kimgho"
---

## 📋 변경 사항

-   import {renderHook,act} from "@testing-library/react-hooks"에서 import module 수정
-   기존 renderHook과 act의 경우 이전 버전에서 지원했지만, act의 경우, from "react"로, renderHook같은 경우 @testing-library/react로 흡수되었음
-  따라서 test했을 때 pass는 했지만 console Error가 나왔던 상황에서 더 이상 Error message가 안 나오게 됐음



